### PR TITLE
Forward exceptions from user iterables to the main thread

### DIFF
--- a/concurrent_iterator/__init__.py
+++ b/concurrent_iterator/__init__.py
@@ -9,6 +9,11 @@ __version__ = '0.2.2'
 class StopIterationSentinel(object):
     """Sentinel to signal the end of data."""
 
+class ExceptionInUserIterable(object):
+    """User-provided iterable raises an exception."""
+
+    def __init__(self, exception):
+        self.exception = exception
 
 class IProducer(Iterator):
     """Interface for Producers.

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -44,6 +44,17 @@ class ProducerTestMixin(object):
         self.assertEqual(list(range(count)), results)
         self.assertAlmostEqual(0, tf, 1)
 
+    def test_when_iterable_throws(self):
+        def throwing_generator():
+            yield
+            raise RuntimeError
+
+        iterable = throwing_generator()
+        subject = self._create_producer(iterable)
+
+        with self.assertRaises(RuntimeError):
+            list(subject)
+
 
 class ConsumerTestMixin(object):
     __metaclass__ = abc.ABCMeta


### PR DESCRIPTION
If a user iterable throws an exception, it will be forwarded to the main thread. However iteration over the iterable is not stopped since the exception can be temporary one
