### PR TITLE
Support ring buffer policy for the thread consumer

### DIFF
--- a/concurrent_iterator/thread_ring_queue.py
+++ b/concurrent_iterator/thread_ring_queue.py
@@ -1,0 +1,24 @@
+# vim: set fileencoding=utf-8
+
+from collections import deque
+from time import sleep
+
+class RingQueue(object):
+    """A simple wrapper around deque to mimic the Queue operations"""
+    def __init__(self, maxsize):
+        super(RingQueue, self).__init__()
+        self._deque = deque(maxlen=maxsize)
+
+    def put(self, item):
+        self._deque.append(item)
+
+    def get(self):
+        while True:
+            try:
+                return self._deque.pop()
+            except IndexError:
+                sleep(1e-3)
+
+
+
+

--- a/tests/test_thread.py
+++ b/tests/test_thread.py
@@ -1,14 +1,17 @@
 # vim: set fileencoding=utf-8
+
+from __future__ import division
+
 import itertools
 import logging
 import unittest
 
 from concurrent_iterator.thread import MultiProducer, Producer, Consumer
 from tests import ProducerTestMixin, ConsumerTestMixin
+import time
 
 
 logging.basicConfig(level=logging.WARNING)
-
 
 class ThreadMultiProducerTest(unittest.TestCase):
 
@@ -30,3 +33,30 @@ class ThreadConsumerTest(unittest.TestCase, ConsumerTestMixin):
 
     def _create_consumer(self, coroutine):
         return Consumer(coroutine)
+
+def rotate(iterable, rank):
+    return iterable[-rank:] + iterable[:-rank]
+
+class ThreadRingQueueTest(unittest.TestCase):
+
+    def test_ring_policy_work_correctly(self):
+        def gen(count):
+            for i in range(count):
+                yield i
+
+        count = 5
+        maxsize = 2
+
+        producer = Producer(iter(gen(count)), maxsize=maxsize, policy='ring')
+        result = list(producer)
+        expected_result = rotate(list(gen(count)), int(count / maxsize))[:maxsize]
+
+        self.assertItemsEqual(result, result, expected_result)
+
+    def test_cant_create_policy_with_unknown_policy(self):
+        Producer(iter([1,2,3]), policy='linear')
+        Producer(iter([1,2,3]), policy='ring')
+
+        with self.assertRaises(ValueError):
+            Producer(iter([1,2,3]), policy='mypolicy')
+


### PR DESCRIPTION
In some applications it's required to keep only last  `n` items (the most fresh ones) from a concurrent iterator. The new`policy` parameter in `thread.MultiProducer` addresses the scenario. Internally the parameter selects which of the standard queues to use - either `Queue.Queue` in the case of `linear` policy, or `collections.deque` if `ring` policy is selected.
